### PR TITLE
feat: Style menu items as responsive cards

### DIFF
--- a/Menu.html
+++ b/Menu.html
@@ -19,7 +19,8 @@
 </header>
    
 <main>
-  <div class="product">
+  <div class="menu-container">
+    <div class="product">
     <img src="viazi.jpeg" alt="" width="250px" height="250px">
      <h1>Viazi Karai</h1>
       <p class="Price">Price: ksh100</p>
@@ -94,7 +95,7 @@
      <h1>Mojito</h1>
       <p class="Price">Price: ksh500</p>
   </div>
-
+  </div>
 </main>
       <footer>
         <img src="logo 5.jpeg" alt=""  width="300px" height="300px" class="center-logo">

--- a/style.css
+++ b/style.css
@@ -91,17 +91,30 @@ h3{
    }
   
  
+  .menu-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 10px;
+  }
   .product{
-    display: inline-block;
+    border: 1px solid #ddd;
+    box-shadow: 2px 2px 8px rgba(0,0,0,0.1);
+    padding: 15px;
+    background-color: #fff;
+    border-radius: 8px;
+    margin: 10px;
     height: auto;
     overflow: auto;
     flex-wrap: wrap;
-    width: 30%;
-      margin: 10px;
+    flex: 1 1 300px;
   }
  .product img{
-   border-radius: 50%;
-   
+   border-radius: 6px;
+   width: 100%;
+   height: auto;
+   max-height: 200px;
+   object-fit: cover;
  }
  .product img:hover{
    transform: scale(0.9);
@@ -109,7 +122,30 @@ h3{
    cursor: pointer;
  }
 
+.product h1 {
+    font-size: 1.1em; /* Or adjust as needed */
+    margin-bottom: 8px;
+    color: #333333; /* Darker text for better readability */
+    /* text-align: center; is already global for h1, so it will be inherited */
+}
 
+.product p.Price {
+    font-size: 1em; /* Or adjust as needed */
+    color: #007bff; /* Standard price color */
+    font-weight: bold;
+    margin-top: 10px; /* Add some space above the price */
+    /* text-align: center; is already global for p, so it will be inherited */
+}
 
+@media (max-width: 768px) {
+  .product {
+    flex-basis: calc(50% - 20px); /* 2 cards per row, accounting for margin */
+  }
+}
 
-
+@media (max-width: 480px) {
+  .product {
+    flex-basis: calc(100% - 20px); /* 1 card per row, accounting for margin */
+  }
+}
+/* Added newline */


### PR DESCRIPTION
I've refactored Menu.html by wrapping product items in a 'menu-container'.

I've updated style.css to:
- Apply card-like styling (border, shadow, padding, background) to product items.
- Implement a responsive flexbox grid for the menu cards, adjusting layout for different screen sizes.
- Restyle product images to fit the card design.
- Refine typography for item names and prices within cards for better readability and visual appeal.

These changes enhance the visual presentation and user experience of the menu page.